### PR TITLE
Add explicit include for musl

### DIFF
--- a/include/lsquic_types.h
+++ b/include/lsquic_types.h
@@ -8,6 +8,7 @@
  */
 
 #include <stdint.h>
+#include <sys/types.h>
 
 #define MAX_CID_LEN 20
 #define GQUIC_CID_LEN 8


### PR DESCRIPTION
On Alpine Linux, `<sys/types.h>` is not included by default, meaning compilation will fail as e.g. `ssize_t` is undefined. This just makes that include explicit.

For reference see [lsquic-alpine](https://github.com/omarroth/lsquic-alpine/blob/master/APKBUILD).